### PR TITLE
Also include SystemDrive environment variable

### DIFF
--- a/pyperf/_utils.py
+++ b/pyperf/_utils.py
@@ -350,7 +350,7 @@ def abs_executable(python):
 def create_environ(inherit_environ, locale):
     env = {}
 
-    copy_env = ["PATH", "HOME", "TEMP", "COMSPEC", "SystemRoot"]
+    copy_env = ["PATH", "HOME", "TEMP", "COMSPEC", "SystemRoot", "SystemDrive"]
     if locale:
         copy_env.extend(('LANG', 'LC_ADDRESS', 'LC_ALL', 'LC_COLLATE',
                          'LC_CTYPE', 'LC_IDENTIFICATION', 'LC_MEASUREMENT',


### PR DESCRIPTION
While running benchmarks against 3.8.0rc1, I noticed a `%SystemDrive%` folder being created in my working directory. Turns out some parts of Windows assume that this environment variable will be set (probably incorrectly, but 🤷‍♂️). There were also some weird crashes that were resolved by providing this variable.

Ensuring it is passed along with `--inherit-environ` is a workaround, but including it by default seems more robust.